### PR TITLE
disable autobind

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -1,5 +1,6 @@
 (function () {
   var forms = {};
+  var globalEditModeEnabled = true;
 
   $('.fl-form').each(function () {
     var connection;
@@ -185,11 +186,18 @@
       }
     }
 
-    bindEditMode();
+    Fliplet.Navigator.onReady().then(function () {
+      if (globalEditModeEnabled) {
+        bindEditMode();
+      }
+    });
   });
 
   Fliplet.Widget.register('com.fliplet.form', function () {
     return {
+      disableAutoBindMode: function () {
+        globalEditModeEnabled = false;
+      },
       forms: function (uuid) {
         if (uuid) {
           return forms[uuid];


### PR DESCRIPTION
```js
// Make sure this runs before the onReady
// e.g. you can run it onPluginsReady

Fliplet.Navigator.onPluginsReady().then(function () {
  var formWidget = Fliplet.Widget.get('com.fliplet.form');
  
  // this will disable the from from autobinding the edit mode on dom ready
  if (formWidget) formWidget.disableAutoBindMode();
});
```